### PR TITLE
Pull the correct versions of R and Python Dynamically

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -141,7 +141,11 @@ func (opts *installOpts) Validate(args []string) error {
 			return fmt.Errorf("invalid R versions: %w", err)
 		}
 	} else if args[0] == "python" && len(opts.versions) != 0 {
-		err := languages.ValidatePythonVersions(opts.versions)
+		osType, err := operatingsystem.DetectOS()
+		if err != nil {
+			return fmt.Errorf("issue detecting OS: %w", err)
+		}
+		err = languages.ValidatePythonVersions(opts.versions, osType)
 		if err != nil {
 			return fmt.Errorf("invalid Python versions: %w", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
-	github.com/adrg/xdg v0.4.0
+	github.com/hashicorp/go-version v1.6.0
 	github.com/samber/lo v1.37.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
@@ -12,7 +12,6 @@ require (
 )
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
@@ -24,12 +23,10 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/stretchr/testify v1.8.2 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	golang.org/x/exp v0.0.0-20230206171751-46f607a40771 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
-github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
-github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -125,6 +123,8 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
@@ -188,7 +188,6 @@ github.com/spf13/viper v1.15.0 h1:js3yy885G8xwJa6iOISGFwd+qlUo5AvyXb7CiihdtiU=
 github.com/spf13/viper v1.15.0/go.mod h1:fFcTBJxvhhzSJiZy8n+PeW6t8l+KeT/uTARa0jHOQLA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -197,7 +196,6 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
@@ -343,7 +341,6 @@ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=

--- a/internal/languages/R.go
+++ b/internal/languages/R.go
@@ -25,7 +25,7 @@ var nonNumericRVersions = []string{
 	"next", "devel",
 }
 
-type availableVersions struct {
+type availableRVersions struct {
 	RVersions []string `json:"r_versions"`
 }
 
@@ -226,14 +226,19 @@ func RetrieveValidRVersions() ([]string, error) {
 		return nil, errors.New("error in HTTP status code")
 	}
 
-	var availVersions availableVersions
+	var availVersions availableRVersions
 	err = json.NewDecoder(res.Body).Decode(&availVersions)
 	if err != nil {
 		return nil, errors.New("error unmarshalling JSON data")
 	}
 
-	numericVersions := removeElements(availVersions.RVersions, nonNumericRVersions)
-	sortedVersions, err := SortVersions(numericVersions)
+	numericVersions, err := removeElements(availVersions.RVersions, nonNumericRVersions)
+	if err != nil {
+		return nil, err
+	}
+	versions := ConvertStringSlicetoVersionSlice(numericVersions)
+
+	sortedVersions, err := SortVersions(versions)
 	if err != nil {
 		return nil, errors.New("failed to sort versions")
 	}

--- a/internal/languages/R.go
+++ b/internal/languages/R.go
@@ -1,14 +1,18 @@
 package languages
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/samber/lo"
@@ -17,8 +21,12 @@ import (
 	"github.com/sol-eng/wbi/internal/system"
 )
 
-var availableRVersions = []string{
-	"4.2.2", "4.2.1", "4.2.0", "4.1.3", "4.1.2", "4.1.1", "4.1.0", "4.0.5", "4.0.4", "4.0.3", "4.0.2", "4.0.1", "4.0.0", "3.6.3", "3.6.2", "3.6.1", "3.6.0", "3.5.3", "3.5.2", "3.5.1", "3.5.0", "3.4.4", "3.4.3", "3.4.2", "3.4.1", "3.4.0", "3.3.3", "3.3.2", "3.3.1", "3.3.0",
+var nonNumericRVersions = []string{
+	"next", "devel",
+}
+
+type availableVersions struct {
+	RVersions []string `json:"r_versions"`
 }
 
 var globalRPaths = []string{
@@ -52,7 +60,7 @@ func isRDir(path string) (string, bool) {
 	return rpath, false
 }
 
-// Prompts user if they want to install R and does the installation
+// PromptAndInstallR Prompts user if they want to install R and does the installation
 func PromptAndInstallR(osType config.OperatingSystem) ([]string, error) {
 	installRChoice, err := RInstallPrompt()
 	if err != nil {
@@ -133,7 +141,7 @@ func ScanAndHandleRVersions(osType config.OperatingSystem) error {
 	return nil
 }
 
-// Append to a string slice only if the string is not yet in the slice
+// AppendIfMissing Append to a string slice only if the string is not yet in the slice
 func AppendIfMissing(slice []string, s string) []string {
 	for _, ele := range slice {
 		if ele == s {
@@ -179,7 +187,7 @@ func ScanForRVersions() ([]string, error) {
 	return foundVersions, nil
 }
 
-// Prompt users if they would like to install R versions
+// RInstallPrompt Prompt users if they would like to install R versions
 func RInstallPrompt() (bool, error) {
 	name := true
 	prompt := &survey.Confirm{
@@ -192,12 +200,49 @@ func RInstallPrompt() (bool, error) {
 	return name, nil
 }
 
+//func RetrieveValidRVersions() ([]string, error) {
+//	// TODO make this dynamic based on https://cran.r-project.org/src/base/R-4/ and https://cran.r-project.org/src/base/R-3/
+//
+//	return availableRVersions, nil
+//}
+
 func RetrieveValidRVersions() ([]string, error) {
-	// TODO make this dynamic based on https://cran.r-project.org/src/base/R-4/ and https://cran.r-project.org/src/base/R-3/
-	return availableRVersions, nil
+	rVersionURL := "https://cdn.posit.co/r/versions.json"
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+	req, err := http.NewRequestWithContext(context.Background(),
+		http.MethodGet, rVersionURL, nil)
+	if err != nil {
+		return nil, errors.New("error creating request")
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, errors.New("error retrieving JSON data")
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, errors.New("error in HTTP status code")
+	}
+
+	var availVersions availableVersions
+	err = json.NewDecoder(res.Body).Decode(&availVersions)
+	if err != nil {
+		return nil, errors.New("error unmarshalling JSON data")
+	}
+
+	numericVersions := removeElements(availVersions.RVersions, nonNumericRVersions)
+	sortedVersions, err := SortVersions(numericVersions)
+	if err != nil {
+		return nil, errors.New("failed to sort versions")
+	}
+
+	return sortedVersions, nil
+
 }
 
-// Prompt asking users which R version(s) they would like to install
+// RSelectVersionsPrompt Prompt asking users which R version(s) they would like to install
 func RSelectVersionsPrompt(availableRVersions []string) ([]string, error) {
 	var qs = []*survey.Question{
 		{
@@ -222,7 +267,7 @@ func RSelectVersionsPrompt(availableRVersions []string) ([]string, error) {
 	return rVersionsAnswers.RVersions, nil
 }
 
-// Downloads the R installer, and installs R
+// DownloadAndInstallR Downloads the R installer, and installs R
 func DownloadAndInstallR(rVersion string, osType config.OperatingSystem) error {
 	// Create InstallerInfo with the proper information
 	installerInfo, err := PopulateInstallerInfo("r", rVersion, osType)
@@ -230,12 +275,12 @@ func DownloadAndInstallR(rVersion string, osType config.OperatingSystem) error {
 		return fmt.Errorf("PopulateInstallerInfo: %w", err)
 	}
 	// Download installer
-	filepath, err := install.DownloadFile("R", installerInfo.URL, installerInfo.Name)
+	installerPath, err := install.DownloadFile("R", installerInfo.URL, installerInfo.Name)
 	if err != nil {
 		return fmt.Errorf("DownloadR: %w", err)
 	}
 	// Install R
-	err = install.InstallLanguage("r", filepath, osType, rVersion)
+	err = install.InstallLanguage("r", installerPath, osType, rVersion)
 	if err != nil {
 		return fmt.Errorf("InstallLanguage: %w", err)
 	}

--- a/internal/languages/R.go
+++ b/internal/languages/R.go
@@ -200,12 +200,6 @@ func RInstallPrompt() (bool, error) {
 	return name, nil
 }
 
-//func RetrieveValidRVersions() ([]string, error) {
-//	// TODO make this dynamic based on https://cran.r-project.org/src/base/R-4/ and https://cran.r-project.org/src/base/R-3/
-//
-//	return availableRVersions, nil
-//}
-
 func RetrieveValidRVersions() ([]string, error) {
 	rVersionURL := "https://cdn.posit.co/r/versions.json"
 
@@ -236,14 +230,15 @@ func RetrieveValidRVersions() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	versions := ConvertStringSlicetoVersionSlice(numericVersions)
+	versions := ConvertStringSliceToVersionSlice(numericVersions)
 
-	sortedVersions, err := SortVersions(versions)
+	sortedVersions := SortVersionsDesc(versions)
 	if err != nil {
 		return nil, errors.New("failed to sort versions")
 	}
+	stringVersions := ConvertVersionSliceToStringSlice(sortedVersions)
 
-	return sortedVersions, nil
+	return stringVersions, nil
 
 }
 
@@ -423,12 +418,12 @@ func CheckPromtAndSetRSymlinks(rPaths []string) error {
 }
 
 func ValidateRVersions(rVersions []string) error {
-	availableRVersions, err := RetrieveValidRVersions()
+	availRVersions, err := RetrieveValidRVersions()
 	if err != nil {
 		return fmt.Errorf("error retrieving valid R versions: %w", err)
 	}
 	for _, rVersion := range rVersions {
-		if !lo.Contains(availableRVersions, rVersion) {
+		if !lo.Contains(availRVersions, rVersion) {
 			return errors.New("version " + rVersion + " is not a valid R version")
 		}
 	}

--- a/internal/languages/python.go
+++ b/internal/languages/python.go
@@ -253,11 +253,6 @@ func PythonPATHPrompt() (bool, error) {
 	return name, nil
 }
 
-//func RetrieveValidPythonVersions() ([]string, error) {
-//	// TODO make this dynamic based on https://cdn.posit.co/python/versions.json
-//	return availablePythonVersions, nil
-//}
-
 func RetrieveValidPythonVersions(osType config.OperatingSystem) ([]string, error) {
 	pythonVersionURL := "https://cdn.posit.co/python/versions.json"
 
@@ -284,7 +279,7 @@ func RetrieveValidPythonVersions(osType config.OperatingSystem) ([]string, error
 		return nil, errors.New("error unmarshalling JSON data")
 	}
 
-	versions := ConvertStringSlicetoVersionSlice(availVersions.PythonVersions)
+	versions := ConvertStringSliceToVersionSlice(availVersions.PythonVersions)
 
 	unavailPythonVersions := unavailablePythonVersionsByOS(osType)
 
@@ -313,12 +308,13 @@ func RetrieveValidPythonVersions(osType config.OperatingSystem) ([]string, error
 		}
 	}
 
-	sortedVersions, err := SortVersions(versions)
+	sortedVersions := SortVersionsDesc(versions)
 	if err != nil {
 		return nil, errors.New("failed to sort versions")
 	}
+	stringVersions := ConvertVersionSliceToStringSlice(sortedVersions)
 
-	return sortedVersions, nil
+	return stringVersions, nil
 
 }
 

--- a/internal/languages/python.go
+++ b/internal/languages/python.go
@@ -285,26 +285,34 @@ func RetrieveValidPythonVersions(osType config.OperatingSystem) ([]string, error
 	}
 
 	versions := ConvertStringSlicetoVersionSlice(availVersions.PythonVersions)
+
 	unavailPythonVersions := unavailablePythonVersionsByOS(osType)
+
 	if len(unavailPythonVersions.NewestPythonVersions) != 0 {
 		for _, v := range unavailPythonVersions.NewestPythonVersions {
 			versions, err = removeNewerVersions(versions, v)
+			if err != nil {
+				return nil, errors.New("failed removing newer unsupported versions of Python")
+			}
 		}
 	}
 	if len(unavailPythonVersions.OldestPythonVersions) != 0 {
 		for _, v := range unavailPythonVersions.OldestPythonVersions {
 			versions, err = removeOlderVersions(versions, v)
+			if err != nil {
+				return nil, errors.New("failed removing older unsupported versions of Python")
+			}
 		}
 	}
 	if len(unavailPythonVersions.SpecificPythonVersions) != 0 {
 		for _, v := range unavailPythonVersions.SpecificPythonVersions {
 			versions, err = removeSpecificVersions(versions, v)
+			if err != nil {
+				return nil, errors.New("failed removing specific unsupported versions of Python")
+			}
 		}
 	}
 
-	if err != nil {
-		return nil, errors.New("failed removing newer versions")
-	}
 	sortedVersions, err := SortVersions(versions)
 	if err != nil {
 		return nil, errors.New("failed to sort versions")

--- a/internal/languages/versions.go
+++ b/internal/languages/versions.go
@@ -54,18 +54,33 @@ func removeNewerVersions(versions []*version.Version, maxVersion string) ([]*ver
 	return result, nil
 }
 
-func removeOlderVersions(versions []*version.Version, maxVersion string) ([]*version.Version, error) {
-	maxV, err := version.NewVersion(maxVersion)
+func removeOlderVersions(versions []*version.Version, minVersion string) ([]*version.Version, error) {
+	minV, err := version.NewVersion(minVersion)
 	if err != nil {
 		return nil, err
 	}
 	var result []*version.Version
 	for _, v := range versions {
-		if v.Segments()[0] == maxV.Segments()[0] && v.Segments()[1] == maxV.Segments()[1] && v.Segments()[2] > maxV.Segments()[2] {
+		if v.Segments()[0] == minV.Segments()[0] && v.Segments()[1] == minV.Segments()[1] && v.Segments()[2] > minV.Segments()[2] {
 			// Version is newer across Major.Minor versions
 			result = append(result, v)
-		} else if v.Segments()[0] != maxV.Segments()[0] || v.Segments()[1] != maxV.Segments()[1] {
+		} else if v.Segments()[0] != minV.Segments()[0] || v.Segments()[1] != minV.Segments()[1] {
 			// Version is newer only within the same Major.Minor version line
+			result = append(result, v)
+		}
+	}
+	return result, nil
+}
+
+func removeSpecificVersions(versions []*version.Version, specificVersion string) ([]*version.Version, error) {
+	specificV, err := version.NewVersion(specificVersion)
+	if err != nil {
+		return nil, err
+	}
+	var result []*version.Version
+	for _, v := range versions {
+		if v.Segments()[0] != specificV.Segments()[0] || v.Segments()[1] != specificV.Segments()[1] || v.Segments()[2] != specificV.Segments()[2] {
+			// Version is newer across Major.Minor versions
 			result = append(result, v)
 		}
 	}

--- a/internal/languages/versions.go
+++ b/internal/languages/versions.go
@@ -1,0 +1,40 @@
+package languages
+
+import (
+	"github.com/hashicorp/go-version"
+	"sort"
+)
+
+func SortVersions(versionsRaw []string) ([]string, error) {
+	versions := make([]*version.Version, len(versionsRaw))
+	for i, raw := range versionsRaw {
+		v, _ := version.NewVersion(raw)
+
+		versions[i] = v
+	}
+
+	// After this, the versions are sorted in descending order properly sorted
+	sort.Sort(sort.Reverse(version.Collection(versions)))
+
+	var versionStrings []string
+	for _, v := range versions {
+		versionStrings = append(versionStrings, v.String())
+	}
+	return versionStrings, nil
+}
+
+func removeElements(originalElements []string, elementsToRemove []string) []string {
+	// Iterate over the slice to be modified
+	for i := 0; i < len(originalElements); i++ {
+		// Iterate over the elements to be removed
+		for _, elem := range elementsToRemove {
+			if originalElements[i] == elem {
+				// Remove the matching element from the slice
+				originalElements = append(originalElements[:i], originalElements[i+1:]...)
+				i--   // Decrement the index to account for the removed element
+				break // Break out of the inner loop to avoid removing the same element twice
+			}
+		}
+	}
+	return originalElements
+}

--- a/internal/languages/versions.go
+++ b/internal/languages/versions.go
@@ -54,6 +54,24 @@ func removeNewerVersions(versions []*version.Version, maxVersion string) ([]*ver
 	return result, nil
 }
 
+func removeOlderVersions(versions []*version.Version, maxVersion string) ([]*version.Version, error) {
+	maxV, err := version.NewVersion(maxVersion)
+	if err != nil {
+		return nil, err
+	}
+	var result []*version.Version
+	for _, v := range versions {
+		if v.Segments()[0] == maxV.Segments()[0] && v.Segments()[1] == maxV.Segments()[1] && v.Segments()[2] > maxV.Segments()[2] {
+			// Version is newer across Major.Minor versions
+			result = append(result, v)
+		} else if v.Segments()[0] != maxV.Segments()[0] || v.Segments()[1] != maxV.Segments()[1] {
+			// Version is newer only within the same Major.Minor version line
+			result = append(result, v)
+		}
+	}
+	return result, nil
+}
+
 func ConvertStringSlicetoVersionSlice(strings []string) []*version.Version {
 
 	versions := make([]*version.Version, len(strings))

--- a/internal/languages/versions.go
+++ b/internal/languages/versions.go
@@ -6,15 +6,11 @@ import (
 	"sort"
 )
 
-func SortVersions(versions []*version.Version) ([]string, error) {
+func SortVersionsDesc(versions []*version.Version) []*version.Version {
 	// After this, the versions are sorted in descending order properly sorted
 	sort.Sort(sort.Reverse(version.Collection(versions)))
 
-	var versionStrings []string
-	for _, v := range versions {
-		versionStrings = append(versionStrings, v.String())
-	}
-	return versionStrings, nil
+	return versions
 }
 
 func removeElements(originalElements []string, elementsToRemove []string) ([]string, error) {
@@ -87,12 +83,22 @@ func removeSpecificVersions(versions []*version.Version, specificVersion string)
 	return result, nil
 }
 
-func ConvertStringSlicetoVersionSlice(strings []string) []*version.Version {
+func ConvertStringSliceToVersionSlice(strings []string) []*version.Version {
 
 	versions := make([]*version.Version, len(strings))
 	for i, raw := range strings {
 		v, _ := version.NewVersion(raw)
 		versions[i] = v
 	}
+
 	return versions
+}
+
+func ConvertVersionSliceToStringSlice(versions []*version.Version) []string {
+
+	var versionStrings []string
+	for _, v := range versions {
+		versionStrings = append(versionStrings, v.String())
+	}
+	return versionStrings
 }

--- a/internal/languages/versions.go
+++ b/internal/languages/versions.go
@@ -1,18 +1,12 @@
 package languages
 
 import (
+	"errors"
 	"github.com/hashicorp/go-version"
 	"sort"
 )
 
-func SortVersions(versionsRaw []string) ([]string, error) {
-	versions := make([]*version.Version, len(versionsRaw))
-	for i, raw := range versionsRaw {
-		v, _ := version.NewVersion(raw)
-
-		versions[i] = v
-	}
-
+func SortVersions(versions []*version.Version) ([]string, error) {
 	// After this, the versions are sorted in descending order properly sorted
 	sort.Sort(sort.Reverse(version.Collection(versions)))
 
@@ -23,7 +17,10 @@ func SortVersions(versionsRaw []string) ([]string, error) {
 	return versionStrings, nil
 }
 
-func removeElements(originalElements []string, elementsToRemove []string) []string {
+func removeElements(originalElements []string, elementsToRemove []string) ([]string, error) {
+	if originalElements == nil || elementsToRemove == nil {
+		return nil, errors.New("slice and elements arguments cannot be nil")
+	}
 	// Iterate over the slice to be modified
 	for i := 0; i < len(originalElements); i++ {
 		// Iterate over the elements to be removed
@@ -36,5 +33,33 @@ func removeElements(originalElements []string, elementsToRemove []string) []stri
 			}
 		}
 	}
-	return originalElements
+	return originalElements, nil
+}
+
+func removeNewerVersions(versions []*version.Version, maxVersion string) ([]*version.Version, error) {
+	maxV, err := version.NewVersion(maxVersion)
+	if err != nil {
+		return nil, err
+	}
+	var result []*version.Version
+	for _, v := range versions {
+		if v.Segments()[0] == maxV.Segments()[0] && v.Segments()[1] == maxV.Segments()[1] && v.Segments()[2] < maxV.Segments()[2] {
+			// Version is newer across Major.Minor versions
+			result = append(result, v)
+		} else if v.Segments()[0] != maxV.Segments()[0] || v.Segments()[1] != maxV.Segments()[1] {
+			// Version is newer only within the same Major.Minor version line
+			result = append(result, v)
+		}
+	}
+	return result, nil
+}
+
+func ConvertStringSlicetoVersionSlice(strings []string) []*version.Version {
+
+	versions := make([]*version.Version, len(strings))
+	for i, raw := range strings {
+		v, _ := version.NewVersion(raw)
+		versions[i] = v
+	}
+	return versions
 }


### PR DESCRIPTION
This resolves the following issues:

https://github.com/sol-eng/wbi/issues/24
https://github.com/sol-eng/wbi/issues/25

Adds the ability to block specific versions of python for specific osTypes because our builds aren't consistent in any helpful way.

https://connect.rstudioservices.com/python-builds-status/

Also allows you to block Major.Minor versions that are newer than a specific version, because we aren't building for CentOS7 anymore. 