### PR TITLE
Adjust how errors are handled in Package Manager prompts

### DIFF
--- a/internal/packagemanager/verify.go
+++ b/internal/packagemanager/verify.go
@@ -26,7 +26,7 @@ func VerifyPackageManagerURL(packageManagerURL string) (string, error) {
 	fullTestURL := cleanPackageManagerURL + "/__ping__"
 
 	client := &http.Client{
-		Timeout: 30 * time.Second,
+		Timeout: 5 * time.Second,
 	}
 	req, err := http.NewRequestWithContext(context.Background(),
 		http.MethodGet, fullTestURL, nil)
@@ -51,7 +51,7 @@ func VerifyPackageManagerRepo(packageManagerURL string, packageManagerRepo strin
 	repoSearchURL := packageManagerURL + "/__api__/repos?type=" + language
 
 	client := &http.Client{
-		Timeout: 30 * time.Second,
+		Timeout: 5 * time.Second,
 	}
 	req, err := http.NewRequestWithContext(context.Background(),
 		http.MethodGet, repoSearchURL, nil)


### PR DESCRIPTION
This PR closes https://github.com/sol-eng/wbi/issues/118 and works at but does not entirely fix: https://github.com/sol-eng/wbi/issues/66.

Essentially a loop is created for each prompt and verify section, only broken out when a verify is successful or a user types "skip". There is some code needed to make sure that when a user skips, it skips the rest of the package manager prompts so if you skip at the URL stage, you will skip the repo entry too and go to the next set of Connect prompts.