### PR TITLE
Add retries for R and Python

### DIFF
--- a/internal/languages/R.go
+++ b/internal/languages/R.go
@@ -71,10 +71,20 @@ func PromptAndInstallR(osType config.OperatingSystem) ([]string, error) {
 		if err != nil {
 			return []string{}, fmt.Errorf("issue retrieving R versions: %w", err)
 		}
-		installRVersions, err := RSelectVersionsPrompt(validRVersions)
-		if err != nil {
-			return []string{}, fmt.Errorf("issue selecting R versions: %w", err)
+
+		var installRVersions []string
+		for {
+			installRVersions, err = RSelectVersionsPrompt(validRVersions)
+			if err != nil {
+				return []string{}, fmt.Errorf("issue selecting R versions: %w", err)
+			}
+			if len(installRVersions) == 0 {
+				fmt.Println(`No R versions selected. Please select at least one version to install.`)
+			} else {
+				break
+			}
 		}
+
 		for _, rVersion := range installRVersions {
 			err = DownloadAndInstallR(rVersion, osType)
 			if err != nil {
@@ -261,9 +271,7 @@ func RSelectVersionsPrompt(availableRVersions []string) ([]string, error) {
 	if err != nil {
 		return []string{}, errors.New("there was an issue with the R versions selection prompt")
 	}
-	if len(rVersionsAnswers.RVersions) == 0 {
-		return []string{}, errors.New("at least one R version must be selected")
-	}
+
 	return rVersionsAnswers.RVersions, nil
 }
 

--- a/internal/languages/python.go
+++ b/internal/languages/python.go
@@ -124,10 +124,20 @@ func PromptAndInstallPython(osType config.OperatingSystem) ([]string, error) {
 		if err != nil {
 			return []string{}, fmt.Errorf("issue retrieving Python versions: %w", err)
 		}
-		installPythonVersions, err := PythonSelectVersionsPrompt(validPythonVersions)
-		if err != nil {
-			return []string{}, fmt.Errorf("issue selecting Python versions: %w", err)
+
+		var installPythonVersions []string
+		for {
+			installPythonVersions, err = PythonSelectVersionsPrompt(validPythonVersions)
+			if err != nil {
+				return []string{}, fmt.Errorf("issue selecting Python versions: %w", err)
+			}
+			if len(installPythonVersions) == 0 {
+				fmt.Println(`No Python versions selected. Please select at least one version to install.`)
+			} else {
+				break
+			}
 		}
+
 		for _, pythonVersion := range installPythonVersions {
 			err = DownloadAndInstallPython(pythonVersion, osType)
 			if err != nil {
@@ -336,9 +346,6 @@ func PythonSelectVersionsPrompt(availablePythonVersions []string) ([]string, err
 	err := survey.Ask(qs, &pythonVersionsAnswers, survey.WithRemoveSelectAll(), survey.WithRemoveSelectNone())
 	if err != nil {
 		return []string{}, errors.New("there was an issue with the Python versions selection prompt")
-	}
-	if len(pythonVersionsAnswers.PythonVersions) == 0 {
-		return []string{}, errors.New("at least one Python version must be selected")
 	}
 	return pythonVersionsAnswers.PythonVersions, nil
 }


### PR DESCRIPTION
Works at addressing https://github.com/sol-eng/wbi/issues/66

When selecting R and Python versions, if no versions are selected, it will ask for another selection rather than erroring out.