### PR TITLE
Add version sorting of /opt to both R and Python during scanning

### DIFF
--- a/internal/languages/versions.go
+++ b/internal/languages/versions.go
@@ -2,8 +2,10 @@ package languages
 
 import (
 	"errors"
-	"github.com/hashicorp/go-version"
+	"fmt"
 	"sort"
+
+	"github.com/hashicorp/go-version"
 )
 
 func SortVersionsDesc(versions []*version.Version) []*version.Version {
@@ -83,15 +85,18 @@ func removeSpecificVersions(versions []*version.Version, specificVersion string)
 	return result, nil
 }
 
-func ConvertStringSliceToVersionSlice(strings []string) []*version.Version {
+func ConvertStringSliceToVersionSlice(strings []string) ([]*version.Version, error) {
 
 	versions := make([]*version.Version, len(strings))
 	for i, raw := range strings {
-		v, _ := version.NewVersion(raw)
+		v, err := version.NewVersion(raw)
+		if err != nil {
+			return []*version.Version{}, fmt.Errorf("failed to parse version %s: %w", raw, err)
+		}
 		versions[i] = v
 	}
 
-	return versions
+	return versions, nil
 }
 
 func ConvertVersionSliceToStringSlice(versions []*version.Version) []string {


### PR DESCRIPTION
Closes https://github.com/sol-eng/wbi/issues/111

This PR sorts the /opt/R and /opt/python paths in the scanning function for each R and Python. Since the scanning function is used throughout `wbi` from listing initial R and Python paths found to providing options for the choice of Jupyter and extra kernels, this change propagates throughout `wbi` and sorts neatly.