### PR TITLE
Switch to an env variable to ignore root warning

### DIFF
--- a/internal/jupyter/install.go
+++ b/internal/jupyter/install.go
@@ -24,7 +24,7 @@ func InstallJupyter(pythonPath string) error {
 
 // Install various Jupyter related packages from PyPI
 func InstallJupyterAndComponents(pythonPath string) error {
-	licenseCommand := pythonPath + " -m pip install --no-warn-script-location --disable-pip-version-check --root-user-action=ignore jupyter jupyterlab rsp_jupyter rsconnect_jupyter workbench_jupyterlab"
+	licenseCommand := "PIP_ROOT_USER_ACTION=ignore " + pythonPath + " -m pip install --no-warn-script-location --disable-pip-version-check jupyter jupyterlab rsp_jupyter rsconnect_jupyter workbench_jupyterlab"
 	err := system.RunCommand(licenseCommand, true, 2)
 	if err != nil {
 		return fmt.Errorf("issue installing Jupyter with the command '%s': %w", licenseCommand, err)
@@ -111,7 +111,7 @@ func installIpykernel(pythonPath string) error {
 		return fmt.Errorf("issue removing python from the path: %w", err)
 	}
 
-	installCommand := basePath + "/pip install --no-warn-script-location --disable-pip-version-check --root-user-action=ignore ipykernel"
+	installCommand := "PIP_ROOT_USER_ACTION=ignore " + basePath + "/pip install --no-warn-script-location --disable-pip-version-check ipykernel"
 	err = system.RunCommand(installCommand, true, 1)
 	if err != nil {
 		return fmt.Errorf("issue installing ipykernel with the command '%s': %w", installCommand, err)

--- a/internal/languages/python.go
+++ b/internal/languages/python.go
@@ -426,7 +426,7 @@ func DownloadAndInstallPython(pythonVersion string, osType config.OperatingSyste
 }
 
 func UpgradePythonTools(pythonVersion string) error {
-	upgradeCommand := "/opt/python/" + pythonVersion + "/bin/pip install --upgrade --no-warn-script-location --disable-pip-version-check --root-user-action=ignore pip setuptools wheel"
+	upgradeCommand := "PIP_ROOT_USER_ACTION=ignore /opt/python/" + pythonVersion + "/bin/pip install --upgrade --no-warn-script-location --disable-pip-version-check pip setuptools wheel"
 	err := system.RunCommand(upgradeCommand, true, 2)
 	if err != nil {
 		return fmt.Errorf("issue upgrading pip, setuptools and wheel for Python with the command '%s': %w", upgradeCommand, err)


### PR DESCRIPTION
This PR fixes an issue with installing older versions of Python which come with pip versions before 22.1 which currently break due to this option not existing `--root-user-action=ignore`. Instead this PR used the env variable `PIP_ROOT_USER_ACTION=ignore` which will take effect in 22.1 and later but not harm anything before that in older versions. I don't know of any way to actually ignore that error in pip pre 22.1.