### PR TITLE
Add quarto support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can also pass the `--step` flag to begin at a certain spot in the interactiv
 sudo wbi setup --step workbench
 ```
 
-The following steps are valid options: start, prereqs, firewall, security, languages, r, python, workbench, license, jupyter, prodrivers, ssl, packagemanager, connect, restart, status, verify.
+The following steps are valid options: start, prereqs, firewall, security, languages, r, python, workbench, license, quarto, jupyter, prodrivers, ssl, packagemanager, connect, restart, status, verify.
 
 ## Assumptions
 - Single server

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sol-eng/wbi/internal/languages"
 	"github.com/sol-eng/wbi/internal/operatingsystem"
+	"github.com/sol-eng/wbi/internal/quarto"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,6 +25,10 @@ func TestInstallParamsValidate(t *testing.T) {
 	validPythonVersions, err := languages.RetrieveValidPythonVersions(osType)
 	if err != nil {
 		t.Fatalf("failed to retrieve valid Python versions: %v", err)
+	}
+	validQuartoVersions, err := quarto.RetrieveValidQuartoVersions()
+	if err != nil {
+		t.Fatalf("failed to retrieve valid Quarto versions: %v", err)
 	}
 
 	tests := map[string]struct {
@@ -153,6 +158,62 @@ func TestInstallParamsValidate(t *testing.T) {
 			args:        []string{"python"},
 			flags:       installOpts{path: "/opt/python/3.6.1/bin/python"},
 			expectError: "the path flag is only supported for jupyter",
+		},
+		// quarto argument tests
+		"quarto argument only succeeds": {
+			args:        []string{"quarto"},
+			flags:       installOpts{},
+			expectError: "",
+		},
+		"quarto argument with a symlink flag succeeds": {
+			args:        []string{"quarto"},
+			flags:       installOpts{symlink: true},
+			expectError: "",
+		},
+		"quarto argument with a valid quarto version and a symlink flag succeeds": {
+			args:        []string{"quarto"},
+			flags:       installOpts{symlink: true, versions: validQuartoVersions[0:1]},
+			expectError: "",
+		},
+		"quarto argument with an invalid quarto version and a symlink flag fails": {
+			args:        []string{"quarto"},
+			flags:       installOpts{symlink: true, versions: []string{"0.6.1"}},
+			expectError: "version 0.6.1 is not a valid Quarto version",
+		},
+		"quarto argument with single valid version flag succeeds": {
+			args:        []string{"quarto"},
+			flags:       installOpts{versions: validQuartoVersions[0:1]},
+			expectError: "",
+		},
+		"quarto argument with single invalid version flag fails": {
+			args:        []string{"quarto"},
+			flags:       installOpts{versions: []string{"0.6.1"}},
+			expectError: "version 0.6.1 is not a valid Quarto version",
+		},
+		"quarto argument with multiple valid version flags succeeds": {
+			args:        []string{"quarto"},
+			flags:       installOpts{versions: validQuartoVersions[0:2]},
+			expectError: "",
+		},
+		"quarto argument with multiple invalid version flags fails": {
+			args:        []string{"quarto"},
+			flags:       installOpts{versions: []string{"0.6.1", "0.2.2"}},
+			expectError: "version 0.6.1 is not a valid Quarto version",
+		},
+		"quarto argument with one valid and one invalid version flags fails": {
+			args:        []string{"quarto"},
+			flags:       installOpts{versions: []string{validQuartoVersions[0], "0.2.2"}},
+			expectError: "version 0.2.2 is not a valid Quarto version",
+		},
+		"quarto argument with path flag fails": {
+			args:        []string{"quarto"},
+			flags:       installOpts{path: "/opt/python/3.6.1/bin/python"},
+			expectError: "the path flag is only supported for jupyter",
+		},
+		"quarto argument with addToPATH flag fails": {
+			args:        []string{"quarto"},
+			flags:       installOpts{addToPATH: true},
+			expectError: "the add-to-path flag is only supported for python",
 		},
 		// Workbench argument tests
 		"workbench argument only succeeds": {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sol-eng/wbi/internal/operatingsystem"
 	"github.com/sol-eng/wbi/internal/packagemanager"
 	"github.com/sol-eng/wbi/internal/prodrivers"
+	"github.com/sol-eng/wbi/internal/quarto"
 	"github.com/sol-eng/wbi/internal/ssl"
 	"github.com/sol-eng/wbi/internal/system"
 	"github.com/sol-eng/wbi/internal/workbench"
@@ -166,6 +167,15 @@ func newSetup(setupOpts setupOpts) error {
 		if err != nil {
 			return fmt.Errorf("issue checking, prompting or activating license: %w", err)
 		}
+		step = "quarto"
+	}
+
+	if step == "quarto" {
+		// Quarto
+		err := quarto.ScanAndHandleQuartoVersions(osType)
+		if err != nil {
+			return fmt.Errorf("issue scanning, prompting or installing Quarto: %w", err)
+		}
 		step = "jupyter"
 	}
 
@@ -315,7 +325,7 @@ func (opts *setupOpts) Validate(args []string) error {
 		return fmt.Errorf("no arguments are supported for this command")
 	}
 	// ensure step is valid
-	validSteps := []string{"start", "prereqs", "firewall", "security", "languages", "r", "python", "workbench", "license", "jupyter", "prodrivers", "ssl", "packagemanager", "connect", "restart", "status", "verify"}
+	validSteps := []string{"start", "prereqs", "firewall", "security", "languages", "r", "python", "workbench", "license", "quarto", "jupyter", "prodrivers", "ssl", "packagemanager", "connect", "restart", "status", "verify"}
 	if opts.step != "" && !lo.Contains(validSteps, opts.step) {
 		return fmt.Errorf("invalid step: %s", opts.step)
 	}
@@ -357,7 +367,7 @@ func newSetupCmd() *setupCmd {
 		SilenceUsage: true,
 	}
 
-	stepHelp := `The step to start at. Valid steps are: start, prereqs, firewall, security, languages, r, python, workbench, license, jupyter, prodrivers, ssl, packagemanager, connect, restart, status, verify.`
+	stepHelp := `The step to start at. Valid steps are: start, prereqs, firewall, security, languages, r, python, workbench, license, quarto, jupyter, prodrivers, ssl, packagemanager, connect, restart, status, verify.`
 
 	cmd.Flags().StringP("step", "s", "", stepHelp)
 	viper.BindPFlag("step", cmd.Flags().Lookup("step"))

--- a/internal/operatingsystem/prompt.go
+++ b/internal/operatingsystem/prompt.go
@@ -61,8 +61,8 @@ func PromptInstallPrereqs() (bool, error) {
 	var name bool
 	messageText := "In order to install Workbench from start to finish, you will need the following things\n" +
 		"1. Internet access for this server\n" +
-		"2. The versions of R and Python you would like to install\n" +
-		"3. The version of R and Python you would like to set as defaults\n" +
+		"2. The versions of R, Python and Quarto you would like to install\n" +
+		"3. The version of R, Python and Quarto you would like to set as defaults\n" +
 		"4. Your Workbench license key string in this form: XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX\n" +
 		"5. The location on this server of your SSL key and certificate files (optional)\n" +
 		"6. The URL and repo name for your instance of Posit Package Manager (optional)\n" +

--- a/internal/quarto/check.go
+++ b/internal/quarto/check.go
@@ -1,0 +1,68 @@
+package quarto
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sol-eng/wbi/internal/system"
+)
+
+// ScanForBundledQuartoVersion scans for the bundled version of Quarto
+func ScanForBundledQuartoVersion() (string, error) {
+	quartoPath := "/usr/lib/rstudio-server/bin/quarto/bin/quarto"
+	versionCommand := quartoPath + " --version"
+	quartoVersion, err := system.RunCommandAndCaptureOutput(versionCommand, false, 0)
+	if err != nil {
+		return "", fmt.Errorf("issue finding Quarto version: %w", err)
+	}
+	return quartoVersion, nil
+}
+
+func checkForBundledQuartoVersion() (bool, error) {
+	// check if /usr/lib/rstudio-server/bin/quarto/bin/quarto exists
+	_, err := os.Stat("/usr/lib/rstudio-server/bin/quarto/bin/quarto")
+	if err == nil {
+		return true, nil
+	} else if os.IsNotExist(err) {
+		return false, nil
+	} else {
+		return false, err
+	}
+}
+
+func CheckAndSetQuartoSymlink(quartoPath string) error {
+	// check if Quarto has already been symlinked
+	quartoSymlinked := checkIfQuartoSymlinkExists()
+	if !quartoSymlinked {
+		err := setQuartoSymlinks(quartoPath, true)
+		if err != nil {
+			return fmt.Errorf("issue setting Quarto symlinks: %w", err)
+		}
+	} else {
+		system.PrintAndLogInfo("Quarto symlink already exist, skipping symlink creation")
+	}
+	return nil
+}
+
+func checkPromtAndSetQuartoSymlinks(quartoPaths []string) error {
+	// check if Quarto has already been symlinked
+	quartoSymlinked := checkIfQuartoSymlinkExists()
+	if (len(quartoPaths) > 0) && !quartoSymlinked {
+		err := promptAndSetQuartoSymlink(quartoPaths)
+		if err != nil {
+			return fmt.Errorf("issue setting Quarto symlinks: %w", err)
+		}
+	}
+	return nil
+}
+
+// checkIfQuartoSymlinkExists checks if the Quarto symlink exists
+func checkIfQuartoSymlinkExists() bool {
+	_, err := os.Stat("/usr/local/bin/quarto")
+	if err != nil {
+		return false
+	}
+
+	system.PrintAndLogInfo("\nAn existing Quarto symlink has been detected (/usr/local/bin/quarto)")
+	return true
+}

--- a/internal/quarto/install.go
+++ b/internal/quarto/install.go
@@ -99,7 +99,7 @@ func installQuarto(filepath string, osType config.OperatingSystem, version strin
 	// create the /opt/quarto directory if it doesn't exist
 	path := fmt.Sprintf("/opt/quarto/%s", version)
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		err := os.Mkdir(path, 0666)
+		err := os.MkdirAll(path, 0755)
 		if err != nil {
 			return fmt.Errorf("error creating directory: %w", err)
 		}
@@ -156,7 +156,7 @@ func promptAndSetQuartoSymlink(quartoPaths []string) error {
 			return fmt.Errorf("issue setting Quarto symlinks: %w", err)
 		}
 
-		system.PrintAndLogInfo("\nThe selected Quarto directory  " + quartoPathChoice + " has been successfully symlinked and will be available on the default system PATH.\n")
+		system.PrintAndLogInfo("\n " + quartoPathChoice + " has been successfully symlinked and will be available on the default system PATH.\n")
 	}
 	return nil
 }
@@ -164,7 +164,7 @@ func promptAndSetQuartoSymlink(quartoPaths []string) error {
 // setQuartoSymlinks sets the Quarto symlink
 func setQuartoSymlinks(quartoPath string) error {
 	quartoCommand := "ln -s " + quartoPath + " /usr/local/bin/quarto"
-	err := system.RunCommand(quartoCommand, true, 0)
+	err := system.RunCommand(quartoCommand, false, 0)
 	if err != nil {
 		return fmt.Errorf("error setting Quarto symlink with the command '%s': %w", quartoCommand, err)
 	}

--- a/internal/quarto/install.go
+++ b/internal/quarto/install.go
@@ -1,0 +1,209 @@
+package quarto
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/AlecAivazis/survey/v2"
+	log "github.com/sirupsen/logrus"
+	"github.com/sol-eng/wbi/internal/config"
+	"github.com/sol-eng/wbi/internal/system"
+)
+
+func RetrieveValidQuartoVersions(osType config.OperatingSystem) ([]string, error) {
+	// TODO automate the retrieving the list of valid versions
+	return []string{"1.3.340", "1.2.475", "1.1.189", "1.0.38"}, nil
+}
+
+func DownloadAndInstallQuartoVersions(quartoVersions []string, osType config.OperatingSystem) error {
+	for _, quartoVersion := range quartoVersions {
+		err := DownloadAndInstallQuarto(quartoVersion, osType)
+		if err != nil {
+			return fmt.Errorf("issue installing Quarto version: %w", err)
+		}
+	}
+	return nil
+}
+
+func DownloadAndInstallQuarto(quartoVersion string, osType config.OperatingSystem) error {
+	// Find URL
+	quartoURL := generateQuartoInstallURL(quartoVersion, osType)
+	// Download installer
+	installerPath, err := downloadFileQuarto(quartoURL, quartoVersion, osType)
+	if err != nil {
+		return fmt.Errorf("DownloadFileQuarto: %w", err)
+	}
+	// Install Quarto
+	err = installQuarto(installerPath, osType, quartoVersion)
+	if err != nil {
+		return fmt.Errorf("InstallQuarto: %w", err)
+	}
+	return nil
+}
+
+func generateQuartoInstallURL(quartoVersion string, osType config.OperatingSystem) string {
+	// treat RHEL 7 differently as specified here: https://docs.posit.co/resources/install-quarto/#specify-quarto-version-tar
+	var url string
+	if osType == config.Redhat7 {
+		url = fmt.Sprintf("https://github.com/quarto-dev/quarto-cli/releases/download/v%s/quarto-%s-linux-rhel7-amd64.tar.gz", quartoVersion, quartoVersion)
+	} else {
+		url = fmt.Sprintf("https://github.com/quarto-dev/quarto-cli/releases/download/v%s/quarto-%s-linux-amd64.tar.gz", quartoVersion, quartoVersion)
+	}
+	return url
+}
+
+func downloadFileQuarto(url string, version string, osType config.OperatingSystem) (string, error) {
+	system.PrintAndLogInfo("Downloading Quarto Version: " + version + " installer from: " + url)
+
+	// Create the file
+	filename := "*_" + fmt.Sprintf("quarto-%s-linux-amd64.tar.gz", version)
+	tmpFile, err := os.CreateTemp("", filename)
+	if err != nil {
+		return tmpFile.Name(), err
+	}
+	defer tmpFile.Close()
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+	req, err := http.NewRequestWithContext(context.Background(),
+		http.MethodGet, url, nil)
+	if err != nil {
+		return "", errors.New("error creating request")
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return "", errors.New("error downloading " + filename + " installer")
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return "", errors.New("error retrieving " + filename + " installer")
+	}
+
+	// Writer the body to file
+	_, err = io.Copy(tmpFile, res.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return tmpFile.Name(), nil
+}
+
+// Installs Quarto
+func installQuarto(filepath string, osType config.OperatingSystem, version string) error {
+	// create the /opt/quarto directory if it doesn't exist
+	path := fmt.Sprintf("/opt/quarto/%s", version)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		err := os.Mkdir(path, 0666)
+		if err != nil {
+			return fmt.Errorf("error creating directory: %w", err)
+		}
+	}
+
+	installCommand := fmt.Sprintf(`tar -zxvf "%s" -C "%s" --strip-components=1`, filepath, path)
+
+	err := system.RunCommand(installCommand, false, 0)
+	if err != nil {
+		return fmt.Errorf("the command '%s' failed to run: %w", installCommand, err)
+	}
+
+	successMessage := "\nQuarto version " + version + " successfully installed!\n"
+	system.PrintAndLogInfo(successMessage)
+	return nil
+}
+
+func checkPromtAndSetQuartoSymlinks(quartoPaths []string) error {
+	// check if Quarto has already been symlinked
+	quartoSymlinked := checkIfQuartoSymlinkExists()
+	if (len(quartoPaths) > 0) && !quartoSymlinked {
+		err := promptAndSetQuartoSymlink(quartoPaths)
+		if err != nil {
+			return fmt.Errorf("issue setting Quarto symlinks: %w", err)
+		}
+	}
+	return nil
+}
+
+// checkIfQuartoSymlinkExists checks if the Quarto symlink exists
+func checkIfQuartoSymlinkExists() bool {
+	_, err := os.Stat("/usr/local/bin/quarto")
+	if err != nil {
+		return false
+	}
+
+	system.PrintAndLogInfo("\nAn existing Quarto symlink has been detected (/usr/local/bin/quarto)")
+	return true
+}
+
+// promptAndSetQuartoSymlinks prompts user to set the Quarto symlink
+func promptAndSetQuartoSymlink(quartoPaths []string) error {
+	setQuartoSymlinkChoice, err := quartoSymlinkPrompt()
+	if err != nil {
+		return fmt.Errorf("an issue occured during the selection of Quarto symlink choice: %w", err)
+	}
+	if setQuartoSymlinkChoice {
+		quartoPathChoice, err := quartoLocationSymlinksPrompt(quartoPaths)
+		if err != nil {
+			return fmt.Errorf("issue selecting Quarto binary to add symlinks: %w", err)
+		}
+		err = setQuartoSymlinks(quartoPathChoice)
+		if err != nil {
+			return fmt.Errorf("issue setting Quarto symlinks: %w", err)
+		}
+
+		system.PrintAndLogInfo("\nThe selected Quarto directory  " + quartoPathChoice + " has been successfully symlinked and will be available on the default system PATH.\n")
+	}
+	return nil
+}
+
+// setQuartoSymlinks sets the Quarto symlink
+func setQuartoSymlinks(quartoPath string) error {
+	quartoCommand := "ln -s " + quartoPath + " /usr/local/bin/quarto"
+	err := system.RunCommand(quartoCommand, true, 0)
+	if err != nil {
+		return fmt.Errorf("error setting Quarto symlink with the command '%s': %w", quartoCommand, err)
+	}
+	return nil
+}
+
+// quartoLocationSymlinksPrompt asks users which Quarto binary they want to symlink
+func quartoLocationSymlinksPrompt(quartoPaths []string) (string, error) {
+	// Allow the user to select a version of Quarto to target
+	target := ""
+	messageText := "Select a Quarto binary to symlink:"
+	prompt := &survey.Select{
+		Message: messageText,
+		Options: quartoPaths,
+	}
+	err := survey.AskOne(prompt, &target)
+	if err != nil {
+		return "", errors.New("there was an issue with the Quarto selection prompt for symlinking")
+	}
+	if target == "" {
+		return target, errors.New("no Quarto binary selected to be symlinked")
+	}
+	log.Info(messageText)
+	log.Info(target)
+	return target, nil
+}
+
+// quartoSymlinkPrompt asks users if they would like to set the quarto symlink
+func quartoSymlinkPrompt() (bool, error) {
+	name := true
+	messageText := `Would you like to symlink a Quarto version to make it available on PATH? This is recommended so Workbench can default to this version of Quarto in each of the IDEs and users can type "quarto" in the terminal.`
+	prompt := &survey.Confirm{
+		Message: messageText,
+	}
+	err := survey.AskOne(prompt, &name)
+	if err != nil {
+		return false, errors.New("there was an issue with the symlink Quarto prompt")
+	}
+	log.Info(messageText)
+	log.Info(fmt.Sprintf("%v", name))
+	return name, nil
+}

--- a/internal/quarto/prompt.go
+++ b/internal/quarto/prompt.go
@@ -1,0 +1,124 @@
+package quarto
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+	log "github.com/sirupsen/logrus"
+	"github.com/sol-eng/wbi/internal/config"
+	"github.com/sol-eng/wbi/internal/system"
+)
+
+func ScanAndHandleQuartoVersions(osType config.OperatingSystem) error {
+	// detect the bundled Quarto version
+	quartoBundledVersion, err := ScanForBundledQuartoVersion()
+	if err != nil {
+		return fmt.Errorf("issue scanning for bundled Quarto version: %w", err)
+	}
+	// prompt the user to present the bundled version and ask if they want to install any other versions
+	quartoInstall, err := PromptQuartoInstall(quartoBundledVersion)
+	if err != nil {
+		return fmt.Errorf("there was an issue prompting for Quarto install: %w", err)
+	}
+
+	if quartoInstall {
+		// retrieve other versions and present them to the user
+		validQuartoVersions, err := RetrieveValidQuartoVersions(osType)
+		if err != nil {
+			return fmt.Errorf("there was an issue retrieving valid Quarto versions: %w", err)
+		}
+		installQuartoVersions, err := QuartoSelectVersionsPrompt(validQuartoVersions)
+		if err != nil {
+			return fmt.Errorf("issue selecting Quarto versions: %w", err)
+		}
+		if len(installQuartoVersions) > 0 {
+			// install the version(s)
+			err = DownloadAndInstallQuartoVersions(installQuartoVersions, osType)
+			if err != nil {
+				return fmt.Errorf("there was an issue installing Quarto versions: %w", err)
+			}
+			// ask which version they want to use for default and symlink it to /usr/local/bin/quarto so Jupyter and VS Code will pick it up
+			quartoPaths := append(quartoVersionsToPaths(installQuartoVersions), "/usr/lib/rstudio-server/bin/quarto/bin/quarto")
+			err = checkPromtAndSetQuartoSymlinks(quartoPaths)
+			if err != nil {
+				return fmt.Errorf("there was an issue setting Quarto symlinks: %w", err)
+			}
+		} else {
+			// continue with the bundled version and symlink it to /usr/local/bin/quarto so Jupyter and VS Code will pick it up
+			err = setQuartoSymlinks("/usr/lib/rstudio-server/bin/quarto/bin/quarto")
+			if err != nil {
+				return fmt.Errorf("issue setting Quarto symlinks: %w", err)
+			}
+		}
+	} else {
+		// continue with the bundled version and symlink it to /usr/local/bin/quarto so Jupyter and VS Code will pick it up
+		err = setQuartoSymlinks("/usr/lib/rstudio-server/bin/quarto/bin/quarto")
+		if err != nil {
+			return fmt.Errorf("issue setting Quarto symlinks: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// quartoVersionsToPaths converts Quarto versions to full paths in /opt
+func quartoVersionsToPaths(quartoVersions []string) []string {
+	quartoPaths := []string{}
+	for _, version := range quartoVersions {
+		quartoPaths = append(quartoPaths, "/opt/quarto/"+version+"/bin/quarto")
+	}
+	return quartoPaths
+}
+
+func PromptQuartoInstall(bundledVersion string) (bool, error) {
+	name := false
+	messageText := "Workbench bundles Quarto version " + bundledVersion + ". Would you like to install any different version(s)?"
+	prompt := &survey.Confirm{
+		Message: messageText,
+	}
+	err := survey.AskOne(prompt, &name)
+	if err != nil {
+		return false, errors.New("there was an issue with Quarto install prompt question")
+	}
+	log.Info(messageText)
+	log.Info(fmt.Sprintf("%v", name))
+	return name, nil
+}
+
+// QuartoSelectVersionsPrompt Prompt asking users which Quarto version(s) they would like to install
+func QuartoSelectVersionsPrompt(availableQuartoVersions []string) ([]string, error) {
+	messageText := "Which version(s) of Quarto would you like to install?"
+	var qs = []*survey.Question{
+		{
+			Name: "quartoversions",
+			Prompt: &survey.MultiSelect{
+				Message: messageText,
+				Options: availableQuartoVersions,
+				Default: availableQuartoVersions[0],
+			},
+		},
+	}
+	quartoVersionsAnswers := struct {
+		QuartoVersions []string `survey:"quartoversions"`
+	}{}
+	err := survey.Ask(qs, &quartoVersionsAnswers, survey.WithRemoveSelectAll(), survey.WithRemoveSelectNone())
+	if err != nil {
+		return []string{}, errors.New("there was an issue with the Quarto versions selection prompt")
+	}
+	log.Info(messageText)
+	log.Info(strings.Join(quartoVersionsAnswers.QuartoVersions, ", "))
+	return quartoVersionsAnswers.QuartoVersions, nil
+}
+
+// ScanForBundledQuartoVersion scans for the bundled version of Quarto
+func ScanForBundledQuartoVersion() (string, error) {
+	quartoPath := "/usr/lib/rstudio-server/bin/quarto/bin/quarto"
+	versionCommand := quartoPath + " --version"
+	quartoVersion, err := system.RunCommandAndCaptureOutput(versionCommand, false, 0)
+	if err != nil {
+		return "", fmt.Errorf("issue finding Quarto version: %w", err)
+	}
+	return quartoVersion, nil
+}

--- a/internal/quarto/prompt.go
+++ b/internal/quarto/prompt.go
@@ -74,7 +74,7 @@ func quartoVersionsToPaths(quartoVersions []string) []string {
 
 func PromptQuartoInstall(bundledVersion string) (bool, error) {
 	name := false
-	messageText := "Workbench bundles Quarto version " + bundledVersion + ". Would you like to install any different version(s)?"
+	messageText := "Workbench bundles Quarto version " + bundledVersion + " Would you like to install any different version(s)?"
 	prompt := &survey.Confirm{
 		Message: messageText,
 	}


### PR DESCRIPTION
This PR closes https://github.com/sol-eng/wbi/issues/159 and https://github.com/sol-eng/wbi/issues/143

It adds a quarto installation and symlink support to the `wbi install` command as well as a series of quarto install and symlink prompts in the `wbi setup` flow. If the bundled Workbench quarto is detected it lets the user know and askes if they want to install any additional versions of Quarto. If the answer is no, then wbi will still automatically symlink quarto so it works across editors. If the answer is yes, it will let them choose their versions.

Note, currently the Quarto versions are hard coded, TODO to add automatic retrieval from GitHub releases.