### PR TITLE
Change the flow of package manager and update wording

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -226,21 +226,15 @@ func newSetup(setupOpts setupOpts) error {
 		if err != nil {
 			return fmt.Errorf("%w.\nTo return to this step in the setup process use \"wbi setup --step packagemanager\"", err)
 		}
-		if packageManagerChoice {
+		if packageManagerChoice == "Posit Package Manager" {
 			err = packagemanager.InteractivePackageManagerPrompts(osType)
 			if err != nil {
 				return fmt.Errorf("%w.\nTo return to this step in the setup process use \"wbi setup --step packagemanager\"", err)
 			}
-		} else {
-			publicPackageManagerChoice, err := packagemanager.PromptPublicPackageManagerChoice()
+		} else if packageManagerChoice == "Posit Public Package Manager" {
+			err = packagemanager.VerifyAndBuildPublicPackageManager(osType)
 			if err != nil {
 				return fmt.Errorf("%w.\nTo return to this step in the setup process use \"wbi setup --step packagemanager\"", err)
-			}
-			if publicPackageManagerChoice {
-				err = packagemanager.VerifyAndBuildPublicPackageManager(osType)
-				if err != nil {
-					return fmt.Errorf("%w.\nTo return to this step in the setup process use \"wbi setup --step packagemanager\"", err)
-				}
 			}
 		}
 		step = "connect"

--- a/internal/connect/prompt.go
+++ b/internal/connect/prompt.go
@@ -14,7 +14,7 @@ import (
 // Prompt users if they wish to add a default Connect URL to Workbench
 func PromptConnectChoice() (bool, error) {
 	name := true
-	messageText := "Would you like to provide a default Connect URL for Workbench?"
+	messageText := "Would you like to provide a default Connect URL for Workbench? You will need connectivity to the Connect server to use this option."
 	prompt := &survey.Confirm{
 		Message: messageText,
 	}

--- a/internal/packagemanager/prompt.go
+++ b/internal/packagemanager/prompt.go
@@ -14,19 +14,21 @@ import (
 )
 
 // Prompt users if they wish to add a default Posit Package Manager URL to Workbench
-func PromptPackageManagerChoice() (bool, error) {
-	name := true
-	messageText := "Would you like to setup Posit Package Manager as the default R and/or Python repo in Workbench? You will need connectivity to the Package Manager server to use this option."
-	prompt := &survey.Confirm{
+func PromptPackageManagerChoice() (string, error) {
+	choice := ""
+	messageText := "Would you like to setup Posit Package Manager or Posit Public Package Manager as the default R and/or Python repo for Workbench? You will need connectivity to the Package Manager server to use this option."
+	prompt := &survey.Select{
 		Message: messageText,
+		Options: []string{"Posit Package Manager", "Posit Public Package Manager", "Skip"},
+		Default: "Posit Public Package Manager",
 	}
-	err := survey.AskOne(prompt, &name)
+	err := survey.AskOne(prompt, &choice)
 	if err != nil {
-		return false, errors.New("there was an issue with the Posit Package Manager choice prompt")
+		return "", errors.New("there was an issue with the Posit Package Manager choice prompt")
 	}
 	log.Info(messageText)
-	log.Info(fmt.Sprintf("%v", name))
-	return name, nil
+	log.Info(fmt.Sprintf("%v", choice))
+	return choice, nil
 }
 
 func InteractivePackageManagerPrompts(osType config.OperatingSystem) error {


### PR DESCRIPTION
Closes https://github.com/sol-eng/wbi/issues/164

This PR gives the user of setup the option of selecting Posit Package Manager, Posit Public Package Manager or Skipping entirely to make the Posit Public Package Manager option more obvious. Many customers use Posit Public Package Manager so making it obvious and an easy default will help installs go smoother.