### PR TITLE
Dynamic quarto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist/
 dist/
 *.log
 *.sh
+*.py

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -26,19 +26,12 @@ func TestInstallParamsValidate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to retrieve valid Python versions: %v", err)
 	}
-	var validQuartoVersions []string
 
-	for pagenum := 1; pagenum <= 5; pagenum++ {
-		pagedQuartionVerions, err := quarto.RetrieveValidQuartoVersions(pagenum)
-		if err != nil {
-			t.Fatalf("error retrieving valid Quarto versions: %v", err)
-		}
-		validQuartoVersions = append(validQuartoVersions, pagedQuartionVerions...)
-		if len(validQuartoVersions) > 10 {
-			pagenum = 5
-
-		}
+	validQuartoVersions, err := quarto.RetrieveValidQuartoVersions()
+	if err != nil {
+		t.Fatalf("error retrieving valid Quarto versions: %v", err)
 	}
+
 	if err != nil {
 		t.Fatalf("failed to retrieve valid Quarto versions: %v", err)
 	}

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -26,7 +26,19 @@ func TestInstallParamsValidate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to retrieve valid Python versions: %v", err)
 	}
-	validQuartoVersions, err := quarto.RetrieveValidQuartoVersions()
+	var validQuartoVersions []string
+
+	for pagenum := 1; pagenum <= 5; pagenum++ {
+		pagedQuartionVerions, err := quarto.RetrieveValidQuartoVersions(pagenum)
+		if err != nil {
+			t.Fatalf("error retrieving valid Quarto versions: %v", err)
+		}
+		validQuartoVersions = append(validQuartoVersions, pagedQuartionVerions...)
+		if len(validQuartoVersions) > 10 {
+			pagenum = 5
+
+		}
+	}
 	if err != nil {
 		t.Fatalf("failed to retrieve valid Quarto versions: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,6 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.8.2 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	golang.org/x/exp v0.0.0-20230206171751-46f607a40771 // indirect
 	golang.org/x/net v0.7.0 // indirect

--- a/internal/quarto/install.go
+++ b/internal/quarto/install.go
@@ -2,11 +2,13 @@ package quarto
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -17,16 +19,63 @@ import (
 	"github.com/sol-eng/wbi/internal/system"
 )
 
-func RetrieveValidQuartoVersions() ([]string, error) {
-	// TODO automate the retrieving the list of valid versions
-	return []string{"1.3.340", "1.2.475", "1.1.189", "1.0.38"}, nil
+type Assets []struct {
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+type Quarto []struct {
+	Assets     Assets `json:"assets"`
+	Name       string `json:"name"`
+	Prerelease bool   `json:"prerelease"`
+}
+
+func RetrieveValidQuartoVersions(pagenum int) ([]string, error) {
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+	req, err := http.NewRequestWithContext(context.Background(),
+		http.MethodGet, "https://api.github.com/repos/quarto-dev/quarto-cli/releases?per_page=100&page="+strconv.Itoa(pagenum), nil)
+	if err != nil {
+		return nil, errors.New("error creating request")
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, errors.New("error retrieving JSON data")
+	}
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(res.Body)
+	if res.StatusCode != http.StatusOK {
+		return nil, errors.New("error retrieving JSON data")
+	}
+	var quarto Quarto
+	err = json.NewDecoder(res.Body).Decode(&quarto)
+	if err != nil {
+		return nil, err
+	}
+	var releases []string
+	for _, release := range quarto {
+		if release.Prerelease == false {
+			releases = append(releases, release.Name)
+		}
+	}
+	return releases, nil
 }
 
 func ValidateQuartoVersions(quartoVersions []string) error {
-	availQuartoVersions, err := RetrieveValidQuartoVersions()
-	if err != nil {
-		return fmt.Errorf("error retrieving valid Quarto versions: %w", err)
+	var availQuartoVersions []string
+
+	for pagenum := 1; pagenum <= 5; pagenum++ {
+		pagedQuartionVerions, err := RetrieveValidQuartoVersions(pagenum)
+		if err != nil {
+			return fmt.Errorf("error retrieving valid Quarto versions: %w", err)
+		}
+		availQuartoVersions = append(availQuartoVersions, pagedQuartionVerions...)
+		if len(availQuartoVersions) > 10 {
+			pagenum = 5
+
+		}
 	}
+
 	for _, quartoVersion := range quartoVersions {
 		if !lo.Contains(availQuartoVersions, quartoVersion) {
 			return errors.New("version " + quartoVersion + " is not a valid Quarto version")

--- a/internal/quarto/install.go
+++ b/internal/quarto/install.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -138,9 +139,9 @@ func generateQuartoInstallURL(quartoVersion string, osType config.OperatingSyste
 	// treat RHEL 7 differently as specified here: https://docs.posit.co/resources/install-quarto/#specify-quarto-version-tar
 	var url string
 	if osType == config.Redhat7 {
-		url = fmt.Sprintf("https://github.com/quarto-dev/quarto-cli/releases/download/v%s/quarto-%s-linux-rhel7-amd64.tar.gz", quartoVersion, quartoVersion)
+		url = fmt.Sprintf("https://github.com/quarto-dev/quarto-cli/releases/download/%s/quarto-%s-linux-rhel7-amd64.tar.gz", quartoVersion, strings.Replace(quartoVersion, "v", "", -1))
 	} else {
-		url = fmt.Sprintf("https://github.com/quarto-dev/quarto-cli/releases/download/v%s/quarto-%s-linux-amd64.tar.gz", quartoVersion, quartoVersion)
+		url = fmt.Sprintf("https://github.com/quarto-dev/quarto-cli/releases/download/%s/quarto-%s-linux-amd64.tar.gz", quartoVersion, strings.Replace(quartoVersion, "v", "", -1))
 	}
 	return url
 }

--- a/internal/quarto/install.go
+++ b/internal/quarto/install.go
@@ -28,52 +28,51 @@ type Quarto []struct {
 	Prerelease bool   `json:"prerelease"`
 }
 
-func RetrieveValidQuartoVersions(pagenum int) ([]string, error) {
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-	}
-	req, err := http.NewRequestWithContext(context.Background(),
-		http.MethodGet, "https://api.github.com/repos/quarto-dev/quarto-cli/releases?per_page=100&page="+strconv.Itoa(pagenum), nil)
-	if err != nil {
-		return nil, errors.New("error creating request")
-	}
-	res, err := client.Do(req)
-	if err != nil {
-		return nil, errors.New("error retrieving JSON data")
-	}
-	defer func(Body io.ReadCloser) {
-		_ = Body.Close()
-	}(res.Body)
-	if res.StatusCode != http.StatusOK {
-		return nil, errors.New("error retrieving JSON data")
-	}
-	var quarto Quarto
-	err = json.NewDecoder(res.Body).Decode(&quarto)
-	if err != nil {
-		return nil, err
-	}
-	var releases []string
-	for _, release := range quarto {
-		if release.Prerelease == false {
-			releases = append(releases, release.Name)
+func RetrieveValidQuartoVersions() ([]string, error) {
+	var availQuartoVersions []string
+
+	for pagenum := 1; pagenum < 5; pagenum++ {
+
+		client := &http.Client{
+			Timeout: 30 * time.Second,
+		}
+		req, err := http.NewRequestWithContext(context.Background(),
+			http.MethodGet, "https://api.github.com/repos/quarto-dev/quarto-cli/releases?per_page=100&page="+strconv.Itoa(pagenum), nil)
+		if err != nil {
+			return nil, errors.New("error creating request")
+		}
+		res, err := client.Do(req)
+		if err != nil {
+			return nil, errors.New("error retrieving JSON data")
+		}
+		defer func(Body io.ReadCloser) {
+			_ = Body.Close()
+		}(res.Body)
+		if res.StatusCode != http.StatusOK {
+			return nil, errors.New("error retrieving JSON data")
+		}
+		var quarto Quarto
+		err = json.NewDecoder(res.Body).Decode(&quarto)
+		if err != nil {
+			return nil, err
+		}
+		for _, release := range quarto {
+			if release.Prerelease == false {
+				availQuartoVersions = append(availQuartoVersions, release.Name)
+			}
+		}
+		if len(availQuartoVersions) > 10 {
+			break
 		}
 	}
-	return releases, nil
+	return availQuartoVersions, nil
 }
 
 func ValidateQuartoVersions(quartoVersions []string) error {
-	var availQuartoVersions []string
 
-	for pagenum := 1; pagenum <= 5; pagenum++ {
-		pagedQuartionVerions, err := RetrieveValidQuartoVersions(pagenum)
-		if err != nil {
-			return fmt.Errorf("error retrieving valid Quarto versions: %w", err)
-		}
-		availQuartoVersions = append(availQuartoVersions, pagedQuartionVerions...)
-		if len(availQuartoVersions) > 10 {
-			pagenum = 5
-
-		}
+	availQuartoVersions, err := RetrieveValidQuartoVersions()
+	if err != nil {
+		return fmt.Errorf("error retrieving valid Quarto versions: %w", err)
 	}
 
 	for _, quartoVersion := range quartoVersions {

--- a/internal/quarto/install.go
+++ b/internal/quarto/install.go
@@ -5,14 +5,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/samber/lo"
 	"io"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
+	"sync"
 	"time"
 
-	"github.com/AlecAivazis/survey/v2"
-	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
 	"github.com/sol-eng/wbi/internal/config"
 	cmdlog "github.com/sol-eng/wbi/internal/logging"
@@ -28,31 +30,56 @@ type Quarto []struct {
 	Prerelease bool   `json:"prerelease"`
 }
 
+type result struct {
+	index int
+	res   http.Response
+	err   error
+}
+
 func RetrieveValidQuartoVersions() ([]string, error) {
 	var availQuartoVersions []string
-
+	var results []result
+	var quarto Quarto
+	var urls []string
 	for pagenum := 1; pagenum < 5; pagenum++ {
+		urls = append(urls, "https://api.github.com/repos/quarto-dev/quarto-cli/releases?per_page=100&page="+strconv.Itoa(pagenum))
+	}
+	fmt.Println("Appended URLs")
+	wg := sync.WaitGroup{}
 
-		client := &http.Client{
-			Timeout: 30 * time.Second,
-		}
-		req, err := http.NewRequestWithContext(context.Background(),
-			http.MethodGet, "https://api.github.com/repos/quarto-dev/quarto-cli/releases?per_page=100&page="+strconv.Itoa(pagenum), nil)
-		if err != nil {
-			return nil, errors.New("error creating request")
-		}
-		res, err := client.Do(req)
-		if err != nil {
-			return nil, errors.New("error retrieving JSON data")
-		}
-		defer func(Body io.ReadCloser) {
-			_ = Body.Close()
-		}(res.Body)
-		if res.StatusCode != http.StatusOK {
-			return nil, errors.New("error retrieving JSON data")
-		}
-		var quarto Quarto
-		err = json.NewDecoder(res.Body).Decode(&quarto)
+	for i, url := range urls {
+		fmt.Println("url loop" + strconv.Itoa(i))
+		wg.Add(1)
+		// start a go routine with the index and url in a closure
+		go func(i int, url string) {
+			fmt.Println("Start go func" + strconv.Itoa(i))
+
+			// send the request and put the response in a result struct
+			// along with the index so we can sort them later along with
+			// any error that might have occurred
+			res, err := http.Get(url)
+			if err != nil {
+				return
+			}
+			result := &result{i, *res, err}
+			results = append(results, *result)
+			fmt.Println("End go func " + strconv.Itoa(i))
+			wg.Done()
+
+		}(i, url)
+
+	}
+
+	wg.Wait()
+
+	// let's sort these results real quick
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].index < results[j].index
+	})
+
+	for _, result := range results {
+
+		err := json.NewDecoder(result.res.Body).Decode(&quarto)
 		if err != nil {
 			return nil, err
 		}
@@ -60,9 +87,6 @@ func RetrieveValidQuartoVersions() ([]string, error) {
 			if release.Prerelease == false {
 				availQuartoVersions = append(availQuartoVersions, release.Name)
 			}
-		}
-		if len(availQuartoVersions) > 10 {
-			break
 		}
 	}
 	return availQuartoVersions, nil

--- a/internal/quarto/install.go
+++ b/internal/quarto/install.go
@@ -41,18 +41,16 @@ func RetrieveValidQuartoVersions() ([]string, error) {
 	var results []result
 	var quarto Quarto
 	var urls []string
+
 	for pagenum := 1; pagenum < 5; pagenum++ {
 		urls = append(urls, "https://api.github.com/repos/quarto-dev/quarto-cli/releases?per_page=100&page="+strconv.Itoa(pagenum))
 	}
-	fmt.Println("Appended URLs")
 	wg := sync.WaitGroup{}
 
 	for i, url := range urls {
-		fmt.Println("url loop" + strconv.Itoa(i))
 		wg.Add(1)
 		// start a go routine with the index and url in a closure
 		go func(i int, url string) {
-			fmt.Println("Start go func" + strconv.Itoa(i))
 
 			// send the request and put the response in a result struct
 			// along with the index so we can sort them later along with
@@ -63,7 +61,6 @@ func RetrieveValidQuartoVersions() ([]string, error) {
 			}
 			result := &result{i, *res, err}
 			results = append(results, *result)
-			fmt.Println("End go func " + strconv.Itoa(i))
 			wg.Done()
 
 		}(i, url)

--- a/internal/quarto/prompt.go
+++ b/internal/quarto/prompt.go
@@ -33,7 +33,20 @@ func ScanAndHandleQuartoVersions(osType config.OperatingSystem) error {
 
 	if quartoInstall {
 		// retrieve other versions and present them to the user
-		validQuartoVersions, err := RetrieveValidQuartoVersions()
+		fmt.Printf("Retrieving available Quarto versions...")
+		var validQuartoVersions []string
+
+		for pagenum := 1; pagenum <= 5; pagenum++ {
+			pagedQuartionVerions, err := RetrieveValidQuartoVersions(pagenum)
+			if err != nil {
+				return fmt.Errorf("error retrieving valid Quarto versions: %w", err)
+			}
+			validQuartoVersions = append(validQuartoVersions, pagedQuartionVerions...)
+			if len(validQuartoVersions) > 10 {
+				pagenum = 5
+
+			}
+		}
 		if err != nil {
 			return fmt.Errorf("there was an issue retrieving valid Quarto versions: %w", err)
 		}

--- a/internal/quarto/prompt.go
+++ b/internal/quarto/prompt.go
@@ -34,19 +34,11 @@ func ScanAndHandleQuartoVersions(osType config.OperatingSystem) error {
 	if quartoInstall {
 		// retrieve other versions and present them to the user
 		fmt.Printf("Retrieving available Quarto versions...")
-		var validQuartoVersions []string
-
-		for pagenum := 1; pagenum <= 5; pagenum++ {
-			pagedQuartionVerions, err := RetrieveValidQuartoVersions(pagenum)
-			if err != nil {
-				return fmt.Errorf("error retrieving valid Quarto versions: %w", err)
-			}
-			validQuartoVersions = append(validQuartoVersions, pagedQuartionVerions...)
-			if len(validQuartoVersions) > 10 {
-				pagenum = 5
-
-			}
+		validQuartoVersions, err := RetrieveValidQuartoVersions()
+		if err != nil {
+			return fmt.Errorf("error retrieving valid Quarto versions: %w", err)
 		}
+
 		if err != nil {
 			return fmt.Errorf("there was an issue retrieving valid Quarto versions: %w", err)
 		}


### PR DESCRIPTION
Pull quarto versions dynamically from github API. The results from the API are paginated with 100 results per page and there are a lot of releases.... 1300ish right now. Additionally, I exclude pre-lease versions to make sure we're only installing properly released versions. 