### PR TITLE
Remove Ubuntu18 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ wbi is a CLI tool aimed at streamlining the installation and configuration of Po
 
 ### Apt Install
 
-To install wbi on Ubuntu 18.04, 20.04 or 22.04 using apt install:
+To install wbi on Ubuntu 22.04 or 20.04 using apt install:
 ```
 echo "deb [trusted=yes] https://apt.fury.io/wbi/ /" | sudo tee -a /etc/apt/sources.list.d/fury.list && sudo apt update && sudo apt install wbi
 
@@ -17,7 +17,7 @@ sudo wbi setup
 
 ### Yum Install
 
-To install wbi on RHEL 7/CentOS 7, RHEL 8 or RHEL 9 using yum install:
+To install wbi on RHEL 7/CentOS 7, RHEL 8/CentOS 8 or RHEL 9/CentOS 9 using yum install:
 ```
 sudo tee -a /etc/yum.repos.d/fury.repo > /dev/null <<EOT
 [fury]
@@ -42,12 +42,11 @@ Visit the [release page](https://github.com/sol-eng/wbi/releases) to find instal
 - Internet access (online installation)
 
 ## Supported Operating Systems
-- RHEL 9
-- RHEL 8
+- RHEL 9/CentOS 9
+- RHEL 8/CentOS 8
 - RHEL 7/CentOS 7
 - Ubuntu 22.04
 - Ubuntu 20.04
-- Ubuntu 18.04
 
 ## Usage
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -296,7 +296,7 @@ func newSetup(setupOpts setupOpts) error {
 
 	var adDocURL string
 	switch osType {
-	case config.Ubuntu18, config.Ubuntu20, config.Ubuntu22:
+	case config.Ubuntu20, config.Ubuntu22:
 		adDocURL = "https://support.posit.co/hc/en-us/articles/360024137174-Integrating-Ubuntu-with-Active-Directory-for-RStudio-Workbench-RStudio-Server-Pro"
 	case config.Redhat7, config.Redhat8, config.Redhat9:
 		adDocURL = "https://support.posit.co/hc/en-us/articles/360016587973-Integrating-RStudio-Workbench-RStudio-Server-Pro-with-Active-Directory-using-CentOS-RHEL"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,6 @@ type OperatingSystem int
 
 const (
 	Unknown OperatingSystem = iota
-	Ubuntu18
 	Ubuntu20
 	Ubuntu22
 	Redhat7
@@ -14,8 +13,6 @@ const (
 
 func (os OperatingSystem) ToString() string {
 	switch os {
-	case Ubuntu18:
-		return "Ubuntu 18"
 	case Ubuntu20:
 		return "Ubuntu 20"
 	case Ubuntu22:

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -31,7 +31,7 @@ func InstallLanguage(language string, filepath string, osType config.OperatingSy
 // Creates the proper command to install R/Python based on the operating system
 func RetrieveInstallCommand(filepath string, osType config.OperatingSystem) (string, error) {
 	switch osType {
-	case config.Ubuntu22, config.Ubuntu20, config.Ubuntu18:
+	case config.Ubuntu22, config.Ubuntu20:
 		return "DEBIAN_FRONTEND=noninteractive gdebi -n " + filepath, nil
 	case config.Redhat7, config.Redhat8, config.Redhat9:
 		return "yum install -y " + filepath, nil

--- a/internal/languages/install.go
+++ b/internal/languages/install.go
@@ -16,12 +16,6 @@ type InstallerInfo struct {
 
 func PopulateInstallerInfo(language string, version string, osType config.OperatingSystem) (InstallerInfo, error) {
 	switch osType {
-	case config.Ubuntu18:
-		return InstallerInfo{
-			Name:    language + "-" + version + "_1_amd64.deb",
-			URL:     "https://cdn.rstudio.com/" + language + "/ubuntu-1804/pkgs/" + language + "-" + version + "_1_amd64.deb",
-			Version: version,
-		}, nil
 	case config.Ubuntu20:
 		return InstallerInfo{
 			Name:    language + "-" + version + "_1_amd64.deb",

--- a/internal/logging/command.go
+++ b/internal/logging/command.go
@@ -92,8 +92,6 @@ func DetectOS() (config.OperatingSystem, error) {
 				return config.Ubuntu22, nil
 			} else if strings.Contains(string(releaseVersionUbuntu), "Ubuntu 20") {
 				return config.Ubuntu20, nil
-			} else if strings.Contains(string(releaseVersionUbuntu), "Ubuntu 18") {
-				return config.Ubuntu18, nil
 			} else {
 				return config.Unknown, errors.New("unsupported operating system")
 			}

--- a/internal/operatingsystem/detect.go
+++ b/internal/operatingsystem/detect.go
@@ -38,8 +38,6 @@ func DetectOS() (config.OperatingSystem, error) {
 				return config.Ubuntu22, nil
 			} else if strings.Contains(string(releaseVersionUbuntu), "Ubuntu 20") {
 				return config.Ubuntu20, nil
-			} else if strings.Contains(string(releaseVersionUbuntu), "Ubuntu 18") {
-				return config.Ubuntu18, nil
 			} else {
 				return config.Unknown, errors.New("unsupported operating system")
 			}

--- a/internal/operatingsystem/install.go
+++ b/internal/operatingsystem/install.go
@@ -13,7 +13,7 @@ import (
 func InstallPrereqs(osType config.OperatingSystem) error {
 	system.PrintAndLogInfo("Installing prerequisites...")
 	// Update apt and install gdebi-core if an Ubuntu system
-	if osType == config.Ubuntu22 || osType == config.Ubuntu20 || osType == config.Ubuntu18 {
+	if osType == config.Ubuntu22 || osType == config.Ubuntu20 {
 		AptErr := UpgradeApt()
 		if AptErr != nil {
 			return fmt.Errorf("UpgradeApt: %w", AptErr)
@@ -207,7 +207,7 @@ func DisableFirewall(osType config.OperatingSystem) error {
 	var FWCommand string
 
 	switch osType {
-	case config.Ubuntu18, config.Ubuntu20, config.Ubuntu22:
+	case config.Ubuntu20, config.Ubuntu22:
 		FWCommand = "ufw disable"
 	case config.Redhat7, config.Redhat8, config.Redhat9:
 		FWCommand = "systemctl stop firewalld && systemctl disable firewalld"

--- a/internal/packagemanager/construct.go
+++ b/internal/packagemanager/construct.go
@@ -36,8 +36,6 @@ func BuildPublicPackageManagerFullURL(osType config.OperatingSystem) (string, er
 func ConvertOSTypeToOSName(osType config.OperatingSystem) (string, error) {
 	var osName string
 	switch osType {
-	case config.Ubuntu18:
-		osName = "bionic"
 	case config.Ubuntu20:
 		osName = "focal"
 	case config.Ubuntu22:

--- a/internal/prodrivers/install.go
+++ b/internal/prodrivers/install.go
@@ -107,7 +107,7 @@ func InstallProDrivers(filepath string, osType config.OperatingSystem) error {
 func (pd *ProDrivers) GetInstallerInfo(osType config.OperatingSystem) (InstallerInfo, error) {
 	switch osType {
 	// Posit Pro Drivers are the same for all Ubuntu versions
-	case config.Ubuntu18, config.Ubuntu20, config.Ubuntu22:
+	case config.Ubuntu20, config.Ubuntu22:
 		return pd.ProDrivers.Installer.Focal, nil
 	case config.Redhat7:
 		return pd.ProDrivers.Installer.Redhat7, nil
@@ -147,7 +147,7 @@ func RetrieveProDriversInstallerInfo() (ProDrivers, error) {
 
 // Installs unixODBC and unixODBC-devel
 func InstallUnixODBC(osType config.OperatingSystem) error {
-	if osType == config.Ubuntu22 || osType == config.Ubuntu20 || osType == config.Ubuntu18 {
+	if osType == config.Ubuntu22 || osType == config.Ubuntu20 {
 		prereqCommand := "apt-get -y install unixodbc unixodbc-dev"
 		err := system.RunCommand(prereqCommand, true, 1, true)
 		if err != nil {

--- a/internal/ssl/trust.go
+++ b/internal/ssl/trust.go
@@ -14,7 +14,7 @@ func TrustRootCertificate(rootCA *x509.Certificate, osType config.OperatingSyste
 	var pemCert []string
 	pemCert = append(pemCert, string(pem.EncodeToMemory(&block)))
 	switch osType {
-	case config.Ubuntu18, config.Ubuntu20, config.Ubuntu22:
+	case config.Ubuntu20, config.Ubuntu22:
 		err := system.WriteStrings(pemCert, "/usr/local/share/ca-certificates/workbenchCA.crt", 0755, true, true)
 		if err != nil {
 			return fmt.Errorf("writing certificate to disk failed: %w", err)

--- a/internal/workbench/install.go
+++ b/internal/workbench/install.go
@@ -107,7 +107,7 @@ func InstallWorkbench(filepath string, osType config.OperatingSystem) error {
 // Creates the proper command to install Workbench based on the operating system
 func RetrieveInstallCommandForWorkbench(filepath string, osType config.OperatingSystem) (string, error) {
 	switch osType {
-	case config.Ubuntu22, config.Ubuntu20, config.Ubuntu18:
+	case config.Ubuntu22, config.Ubuntu20:
 		return "DEBIAN_FRONTEND=noninteractive gdebi -n " + filepath, nil
 	case config.Redhat7, config.Redhat8, config.Redhat9:
 		return "yum install -y " + filepath, nil
@@ -119,7 +119,7 @@ func RetrieveInstallCommandForWorkbench(filepath string, osType config.Operating
 // Pulls out the installer information from the JSON data based on the operating system
 func (r *RStudio) GetInstallerInfo(osType config.OperatingSystem) (InstallerInfo, error) {
 	switch osType {
-	case config.Ubuntu18, config.Ubuntu20:
+	case config.Ubuntu20:
 		return r.Rstudio.Pro.Stable.Server.Installer.Focal, nil
 	case config.Ubuntu22:
 		return r.Rstudio.Pro.Stable.Server.Installer.Jammy, nil


### PR DESCRIPTION
Ubuntu 18 is no longer supported by the product. This PR removes all mentions of Ubuntu 18 and closes https://github.com/sol-eng/wbi/issues/178