### PR TITLE
Update github workflow to allow for the building of CGO_ENABLED binaries

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   unit-test:
     runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 1
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Add CGO_ENABLED to the compilation environment to ensure that importing C doesn't cause the build to fail. Since we don't actually use c libraries, we can maintain cross compatibly according to my testing. 